### PR TITLE
Add prettier to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 	"devDependencies": {
 		"@cloudflare/vitest-pool-workers": "^0.8.36",
 		"@types/node": "^22.15.29",
+		"prettier": "^3.0.0",
 		"typescript": "^5.5.2",
 		"vitest": "^3.1.4",
 		"wrangler": "^4.19.1"


### PR DESCRIPTION
This pull request updates the development dependencies in the `package.json` file by adding Prettier.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R16): Added Prettier as a development dependency with version `^3.0.0`.