### PR TITLE
docs: update contributing guidelines for VATSIM Connect setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ Thank you for your interest in contributing to BARS Core! This guide will help y
    1. Create your own D1 database in the Cloudflare Dashboard
    2. Edit `wrangler.toml` and update the database configuration (see comments in the file):
       - `account_id`: Your Cloudflare account ID (found in Cloudflare dashboard URL) (eg: dash.cloudflare.com/your-cloudflare-id/home)
-      - `VATSIM_CLIENT_ID`: Your Your VATSIM Connect application client ID
+      - `VATSIM_CLIENT_ID`: Your VATSIM Connect application client ID
       - `database_name`: Your D1 database name (e.g., "bars-dev")
       - `database_id`: Your D1 database ID (found in Cloudflare Dashboard > D1)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,8 +34,13 @@ Thank you for your interest in contributing to BARS Core! This guide will help y
 
    1. Create your own D1 database in the Cloudflare Dashboard
    2. Edit `wrangler.toml` and update the database configuration (see comments in the file):
+      - `account_id`: Your Cloudflare account ID (found in Cloudflare dashboard URL) (eg: dash.cloudflare.com/your-cloudflare-id/home)
+      - `VATSIM_CLIENT_ID`: Your Your VATSIM Connect application client ID
       - `database_name`: Your D1 database name (e.g., "bars-dev")
       - `database_id`: Your D1 database ID (found in Cloudflare Dashboard > D1)
+
+      > **Note**: To get VATSIM Connect credentials for testing, follow the [VATSIM Connect Sandbox Guide](https://vatsim.dev/services/connect/sandbox) to create a development application and obtain your client ID and secret.
+
    3. Update `package.json` scripts to use your database name:
       - Replace `bars-db` with your database name in the `update-db-local` and `update-db` scripts
 
@@ -51,11 +56,6 @@ Thank you for your interest in contributing to BARS Core! This guide will help y
 
    - `VATSIM_CLIENT_SECRET`: Your VATSIM Connect application secret
    - `AIRPORTDB_API_KEY`: Your AirportDB API key (optional for basic testing)
-
-   **Configure VATSIM Client ID:**
-
-   Edit `wrangler.toml` and update the VATSIM client ID in the `[vars]` section:
-   - `VATSIM_CLIENT_ID`: Replace the default value with your VATSIM Connect application ID
 
    > **Note**: To get VATSIM Connect credentials for testing, follow the [VATSIM Connect Sandbox Guide](https://vatsim.dev/services/connect/sandbox) to create a development application and obtain your client ID and secret.
 


### PR DESCRIPTION
This pull request updates the `CONTRIBUTING.md` file to improve the clarity and organization of the setup instructions for contributors. The changes primarily focus on simplifying the configuration steps for VATSIM Connect and enhancing documentation for better usability.

### Documentation improvements:

* Added detailed instructions for configuring the `account_id` and `VATSIM_CLIENT_ID` in the `wrangler.toml` file, including an example for locating the Cloudflare account ID.
* Reorganized and consolidated the instructions for obtaining VATSIM Connect credentials, replacing redundant sections with a single, clear note linking to the VATSIM Connect Sandbox Guide. [[1]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R37-R43) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L55-L59)
* Removed a redundant section on configuring `VATSIM_CLIENT_ID` in the `[vars]` section of `wrangler.toml`, as this information is now covered in the updated configuration steps.