### PR TITLE
Add R2 Bucket Binding

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -24,7 +24,9 @@ binding = "DB"
 database_name = "bars-db"  # Change this for local testing
 database_id = "0ff8c3d3-bec8-4b1f-8003-691ae35ca396"  # Change this for local testing
 
-#TODO: Add back BARS_STORAGE
+[[r2_buckets]]
+binding = "BARS_STORAGE" # Change this for local testing
+bucket_name = "bars-v2-cdn" # Change this for local testing
 
 [[durable_objects.bindings]]
 name = "BARS"
@@ -32,4 +34,4 @@ class_name = "BARS"
 
 [[migrations]]
 tag = "v1"
-new_sqlite_classes = ["BARS"]
+new_classes = ["BARS"]


### PR DESCRIPTION
This pull request updates the `wrangler.toml` file to improve configuration for local testing and refine the migration setup. The most notable changes involve the addition of an `r2_buckets` binding and adjustments to migration class definitions.

Configuration improvements:

* [`wrangler.toml`](diffhunk://#diff-b1b9719b6eae4103d520f1e902420f5073b5e18a5a47aa73feed71a037557c98L27-R37): Added an `r2_buckets` binding with `BARS_STORAGE` and specified the bucket name as `bars-v2-cdn`.

Migration refinements:

* [`wrangler.toml`](diffhunk://#diff-b1b9719b6eae4103d520f1e902420f5073b5e18a5a47aa73feed71a037557c98L27-R37): Updated the migration configuration by replacing `new_sqlite_classes` with `new_classes` for defining durable object classes.