### PR TITLE
Add endpoint to refresh user API token by VATSIM ID for BARS Staff

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -909,7 +909,7 @@ staffUsersApp.post('/refresh-api-token', async (c) => {
 			}
 		}
 
-		return c.json({ error: message }, status as any);
+		return c.json({ error: message }, status);
 	}
 });
 

--- a/src/services/users.ts
+++ b/src/services/users.ts
@@ -140,10 +140,11 @@ export class UserService {
 
 			return newApiKey;
 		} catch (error) {
+			console.error('Error refreshing user API token:', error);
 			if (error instanceof Error && error.message === 'User not found') {
 				throw error;
 			}
-			throw new Error('Failed to refresh user API token');
+			throw new Error(`Failed to refresh user API token: ${error instanceof Error ? error.message : 'Unknown error'}`);
 		}
 	}
 }

--- a/src/services/users.ts
+++ b/src/services/users.ts
@@ -7,7 +7,7 @@ export class UserService {
 		private db: D1Database,
 		private roles: RoleService,
 		private auth: AuthService,
-	) {}
+	) { }
 
 	// Get all users with pagination
 	async getAllUsers(page: number = 1, limit: number = 10, userId: number): Promise<{ users: UserRecord[]; total: number }> {
@@ -24,7 +24,7 @@ export class UserService {
 				this.db
 					.prepare(
 						`
-            SELECT u.*, 
+            SELECT u.id, u.vatsim_id, u.email, u.created_at, u.last_login,
             CASE WHEN s.id IS NOT NULL THEN 1 ELSE 0 END as is_staff,
             s.role
             FROM users u
@@ -63,7 +63,7 @@ export class UserService {
 			const result = await this.db
 				.prepare(
 					`
-          SELECT u.*, 
+          SELECT u.id, u.vatsim_id, u.email, u.created_at, u.last_login,
           CASE WHEN s.id IS NOT NULL THEN 1 ELSE 0 END as is_staff,
           s.role
           FROM users u
@@ -113,6 +113,37 @@ export class UserService {
 			return true;
 		} catch (error) {
 			throw new Error('Failed to delete user');
+		}
+	}
+
+	// Refresh user's API token by VATSIM ID (lead developers only)
+	async refreshUserApiToken(vatsimId: string, requestingUserId: number): Promise<string> {
+		// Check if user has permission
+		const hasPermission = await this.roles.hasPermission(requestingUserId, StaffRole.LEAD_DEVELOPER);
+		if (!hasPermission) {
+			throw new Error('Unauthorized: Only lead developers can refresh user API tokens');
+		}
+
+		try {
+			// Get the user by VATSIM ID
+			const user = await this.db
+				.prepare('SELECT id FROM users WHERE vatsim_id = ?')
+				.bind(vatsimId)
+				.first<{ id: number }>();
+
+			if (!user) {
+				throw new Error('User not found');
+			}
+
+			// Use the auth service to regenerate the API key
+			const newApiKey = await this.auth.regenerateApiKey(user.id);
+
+			return newApiKey;
+		} catch (error) {
+			if (error instanceof Error && error.message === 'User not found') {
+				throw error;
+			}
+			throw new Error('Failed to refresh user API token');
 		}
 	}
 }


### PR DESCRIPTION
This pull request introduces a new feature for refreshing a user's API token by their VATSIM ID, along with some adjustments to database queries for improved clarity. The most important changes include adding a new POST endpoint, implementing the corresponding service method, and refining the database query fields.

### New Feature: Refresh API Token

* **New POST endpoint for API token refresh**: Added the `/staff/users/refresh-api-token` endpoint in `src/index.ts`. This endpoint allows lead developers to refresh a user's API token using their VATSIM ID. It includes error handling for unauthorized access, missing users, and other potential issues.
* **Service method for API token refresh**: Implemented the `refreshUserApiToken` method in `UserService` in `src/services/users.ts`. This method checks the requesting user's permissions, retrieves the target user by VATSIM ID, and regenerates their API token using the authentication service.

### Code Refinement: Database Query Fields

* **Refined database query fields in `UserService`**: Updated SQL queries in `src/services/users.ts` to explicitly select specific columns (`id`, `vatsim_id`, `email`, `created_at`, `last_login`) instead of using `SELECT *`. This improves query clarity and reduces unnecessary data retrieval. [[1]](diffhunk://#diff-aa6596d2571b986771ee7d413d3a7a49ff2f307375640a567b3e7bf31b2b48aaL27-R27) [[2]](diffhunk://#diff-aa6596d2571b986771ee7d413d3a7a49ff2f307375640a567b3e7bf31b2b48aaL66-R66)