### PR TITLE
Fix copilot mistake.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -909,7 +909,7 @@ staffUsersApp.post('/refresh-api-token', async (c) => {
 			}
 		}
 
-		return c.json({ error: message }, status);
+		return c.json({ error: message }, status as any);
 	}
 });
 


### PR DESCRIPTION
This pull request includes a small change to the `src/index.ts` file. The change updates the return statement in the `staffUsersApp.post('/refresh-api-token', async (c) => {` route handler to cast the `status` variable to `any`.