### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test


### PR DESCRIPTION
Potential fix for [https://github.com/stopbars/Core/security/code-scanning/2](https://github.com/stopbars/Core/security/code-scanning/2)

To fix this issue, we will add a `permissions` block to explicitly define the least-privileged access required for the workflow. Since the workflow appears to only test the project (e.g., type checking, building), it does not require `write` permissions. Therefore, we will set `contents: read` at the root of the workflow to apply this minimal permission to all jobs. This ensures that the `GITHUB_TOKEN` is restricted to read-only access to repository contents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
