### PR TITLE
Add GitHub service, contributors endpoint and openapi docs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,10 +2,10 @@ name: Deploy Core
 
 on:
   push:
-    branches: [main] 
+    branches: [main]
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   deploy:
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -23,10 +25,32 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Generate OpenAPI spec
+        run: |
+          npm run openapi
+          npx prettier --write openapi.json || true
+
+      - name: Commit OpenAPI spec if changed
+        id: commit_spec
+        run: |
+          if git diff --quiet openapi.json; then
+            echo "No spec changes";
+            echo "spec_updated=false" >> $GITHUB_OUTPUT
+          else
+            git config user.name "github-actions"
+            git config user.email "actions@users.noreply.github.com"
+            git add openapi.json
+            git commit -m "chore: update openapi spec"
+            git push
+            echo "spec_updated=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: Prettify code
+        if: steps.commit_spec.outputs.spec_updated == 'false'
         run: npm run prettify
 
       - name: Deploy to Cloudflare Workers
+        if: steps.commit_spec.outputs.spec_updated == 'false'
         run: npx wrangler deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}

--- a/openapi.json
+++ b/openapi.json
@@ -1,0 +1,1549 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "BARS Core API",
+    "version": "1.0.0",
+    "description": "API documentation for BARS Core"
+  },
+  "paths": {
+    "/connect": {
+      "get": {
+        "summary": "Open a real-time connection for an airport",
+        "description": "Upgrades the request to a WebSocket managed by the airport's Durable Object. Requires an API key.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "airport",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 4,
+              "maxLength": 4
+            }
+          },
+          {
+            "in": "query",
+            "name": "key",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "101": {
+            "description": "Switching Protocols (WebSocket established)"
+          },
+          "400": {
+            "description": "Missing airport ID or API key"
+          }
+        }
+      }
+    },
+    "/state": {
+      "get": {
+        "summary": "Get current lighting/network state",
+        "description": "Retrieves real-time state for a specific airport or all active airports.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "airport",
+            "required": true,
+            "description": "ICAO code of airport or 'all' for every active airport",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "State information returned"
+          },
+          "400": {
+            "description": "Missing or invalid airport parameter"
+          }
+        }
+      }
+    },
+    "/auth/vatsim/callback": {
+      "get": {
+        "summary": "VATSIM OAuth callback",
+        "description": "Exchanges authorization code for a VATSIM token and redirects to frontend with token.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "302": {
+            "description": "Redirect to application with token or error"
+          },
+          "400": {
+            "description": "Missing code parameter"
+          }
+        }
+      }
+    },
+    "/auth/account": {
+      "get": {
+        "summary": "Get authenticated account information",
+        "security": [
+          {
+            "VatsimToken": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account found"
+          },
+          "401": {
+            "description": "Missing or invalid token"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        }
+      }
+    },
+    "/auth/regenerate-api-key": {
+      "post": {
+        "summary": "Regenerate API key",
+        "description": "Generates a new API key for the authenticated user (24h cooldown).",
+        "security": [
+          {
+            "VatsimToken": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Key regenerated"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "User not found"
+          },
+          "429": {
+            "description": "Rate limited (cooldown not elapsed)"
+          }
+        }
+      }
+    },
+    "/auth/delete": {
+      "delete": {
+        "summary": "Delete current user account",
+        "security": [
+          {
+            "VatsimToken": []
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Account deleted"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        }
+      }
+    },
+    "/auth/is-staff": {
+      "get": {
+        "summary": "Check staff status",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Staff status returned"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/airports": {
+      "get": {
+        "summary": "Get airport data",
+        "description": "Fetch airport(s) by ICAO(s) or by continent.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "icao",
+            "required": false,
+            "description": "Single ICAO or comma-separated list",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "continent",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Airport data returned"
+          },
+          "400": {
+            "description": "Invalid parameters"
+          },
+          "404": {
+            "description": "Airport not found"
+          }
+        }
+      }
+    },
+    "/divisions": {
+      "get": {
+        "summary": "List all divisions",
+        "security": [
+          {
+            "VatsimToken": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Divisions returned"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a new division",
+        "security": [
+          {
+            "VatsimToken": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "headVatsimId"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "headVatsimId": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Division created"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        }
+      }
+    },
+    "/divisions/user": {
+      "get": {
+        "summary": "Get divisions for current user",
+        "security": [
+          {
+            "VatsimToken": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User divisions returned"
+          }
+        }
+      }
+    },
+    "/divisions/{id}": {
+      "get": {
+        "summary": "Get division details",
+        "security": [
+          {
+            "VatsimToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Division returned"
+          },
+          "404": {
+            "description": "Division not found"
+          }
+        }
+      }
+    },
+    "/divisions/{id}/members": {
+      "get": {
+        "summary": "List division members",
+        "security": [
+          {
+            "VatsimToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Members listed"
+          },
+          "404": {
+            "description": "Division not found"
+          }
+        }
+      },
+      "post": {
+        "summary": "Add member to division",
+        "security": [
+          {
+            "VatsimToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "vatsimId",
+                  "role"
+                ],
+                "properties": {
+                  "vatsimId": {
+                    "type": "string"
+                  },
+                  "role": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Member added"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        }
+      }
+    },
+    "/divisions/{id}/members/{vatsimId}": {
+      "delete": {
+        "summary": "Remove member from division",
+        "security": [
+          {
+            "VatsimToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "vatsimId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Member removed"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        }
+      }
+    },
+    "/divisions/{id}/airports": {
+      "get": {
+        "summary": "List division airports",
+        "security": [
+          {
+            "VatsimToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Airports listed"
+          },
+          "404": {
+            "description": "Division not found"
+          }
+        }
+      },
+      "post": {
+        "summary": "Request airport addition to division",
+        "security": [
+          {
+            "VatsimToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "icao"
+                ],
+                "properties": {
+                  "icao": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Airport request created"
+          },
+          "404": {
+            "description": "Division not found"
+          }
+        }
+      }
+    },
+    "/divisions/{id}/airports/{airportId}/approve": {
+      "post": {
+        "summary": "Approve or reject airport request",
+        "security": [
+          {
+            "VatsimToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "airportId",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "approved"
+                ],
+                "properties": {
+                  "approved": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Airport approval processed"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        }
+      }
+    },
+    "/airports/{icao}/points": {
+      "get": {
+        "summary": "List lighting/navigation points for airport",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "icao",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 4,
+              "maxLength": 4
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Points returned"
+          },
+          "400": {
+            "description": "Invalid ICAO"
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a single point",
+        "security": [
+          {
+            "VatsimToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "icao",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PointData"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Point created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/airports/{icao}/points/batch": {
+      "post": {
+        "summary": "Apply a batch point changeset",
+        "security": [
+          {
+            "VatsimToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "icao",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PointChangeset"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Changeset applied"
+          }
+        }
+      }
+    },
+    "/airports/{icao}/points/{id}": {
+      "put": {
+        "summary": "Update a point",
+        "security": [
+          {
+            "VatsimToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "icao",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Point updated"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete a point",
+        "security": [
+          {
+            "VatsimToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "icao",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Deleted"
+          }
+        }
+      }
+    },
+    "/points/{id}": {
+      "get": {
+        "summary": "Get a single point by ID",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Point found"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/points": {
+      "get": {
+        "summary": "Get multiple points by IDs",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "ids",
+            "required": true,
+            "description": "Comma-separated list of point IDs (max 100)",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Points returned"
+          },
+          "400": {
+            "description": "Validation error"
+          }
+        }
+      }
+    },
+    "/supports/generate": {
+      "post": {
+        "summary": "Generate Light Supports and BARS XML",
+        "description": "Upload raw XML and generate both light supports XML and processed BARS XML.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "xmlFile",
+                  "icao"
+                ],
+                "properties": {
+                  "xmlFile": {
+                    "type": "string",
+                    "format": "binary"
+                  },
+                  "icao": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Generated XML returned"
+          },
+          "400": {
+            "description": "Validation error"
+          }
+        }
+      }
+    },
+    "/notam": {
+      "get": {
+        "summary": "Get global NOTAM",
+        "responses": {
+          "200": {
+            "description": "Current NOTAM returned"
+          }
+        }
+      },
+      "put": {
+        "summary": "Update global NOTAM",
+        "security": [
+          {
+            "VatsimToken": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "content"
+                ],
+                "properties": {
+                  "content": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "NOTAM updated"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        }
+      }
+    },
+    "/public-stats": {
+      "get": {
+        "summary": "Get public usage statistics",
+        "responses": {
+          "200": {
+            "description": "Public stats returned"
+          }
+        }
+      }
+    },
+    "/staff/users": {
+      "get": {
+        "summary": "List users (staff only)",
+        "security": [
+          {
+            "VatsimToken": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Users returned"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/staff/users/search": {
+      "get": {
+        "summary": "Search users (staff only)",
+        "security": [
+          {
+            "VatsimToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "q",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 3
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Search results returned"
+          },
+          "400": {
+            "description": "Invalid query"
+          }
+        }
+      }
+    },
+    "/staff/users/refresh-api-token": {
+      "post": {
+        "summary": "Refresh a user's API token (staff only)",
+        "security": [
+          {
+            "VatsimToken": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "vatsimId"
+                ],
+                "properties": {
+                  "vatsimId": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Token refreshed"
+          }
+        }
+      }
+    },
+    "/staff/users/{id}": {
+      "delete": {
+        "summary": "Delete a user (staff only)",
+        "security": [
+          {
+            "VatsimToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User deletion result"
+          }
+        }
+      }
+    },
+    "/contributions": {
+      "get": {
+        "summary": "List contributions",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "status",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "airport",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "user",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Contributions listed"
+          }
+        }
+      },
+      "post": {
+        "summary": "Submit a new contribution",
+        "security": [
+          {
+            "VatsimToken": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "airportIcao",
+                  "packageName",
+                  "submittedXml"
+                ],
+                "properties": {
+                  "userDisplayName": {
+                    "type": "string"
+                  },
+                  "airportIcao": {
+                    "type": "string"
+                  },
+                  "packageName": {
+                    "type": "string"
+                  },
+                  "submittedXml": {
+                    "type": "string"
+                  },
+                  "notes": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Contribution created"
+          }
+        }
+      }
+    },
+    "/contributions/stats": {
+      "get": {
+        "summary": "Get contribution statistics",
+        "responses": {
+          "200": {
+            "description": "Stats returned"
+          }
+        }
+      }
+    },
+    "/contributions/leaderboard": {
+      "get": {
+        "summary": "Get top contributors",
+        "responses": {
+          "200": {
+            "description": "Leaderboard returned"
+          }
+        }
+      }
+    },
+    "/contributions/top-packages": {
+      "get": {
+        "summary": "Get most used packages",
+        "responses": {
+          "200": {
+            "description": "Package stats returned"
+          }
+        }
+      }
+    },
+    "/contributions/user": {
+      "get": {
+        "summary": "Get current user's contributions",
+        "security": [
+          {
+            "VatsimToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "status",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Contributions returned"
+          }
+        }
+      }
+    },
+    "/contributions/{id}": {
+      "get": {
+        "summary": "Get a specific contribution",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Contribution returned"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete a contribution",
+        "security": [
+          {
+            "VatsimToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Deletion result"
+          }
+        }
+      }
+    },
+    "/contributions/{id}/decision": {
+      "post": {
+        "summary": "Approve or reject a contribution",
+        "security": [
+          {
+            "VatsimToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "approved"
+                ],
+                "properties": {
+                  "approved": {
+                    "type": "boolean"
+                  },
+                  "rejectionReason": {
+                    "type": "string"
+                  },
+                  "newPackageName": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Decision processed"
+          },
+          "403": {
+            "description": "Not authorized"
+          }
+        }
+      }
+    },
+    "/contributions/user/display-name": {
+      "get": {
+        "summary": "Get display name for authenticated user",
+        "security": [
+          {
+            "VatsimToken": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Display name returned"
+          }
+        }
+      }
+    },
+    "/staff-stats": {
+      "get": {
+        "summary": "Get internal staff statistics (restricted)",
+        "security": [
+          {
+            "VatsimToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "days",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "stat",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Stats returned"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        }
+      }
+    },
+    "/cdn/files/{fileKey}": {
+      "get": {
+        "summary": "Download a file from CDN",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "fileKey",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File stream"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete a file (staff only)",
+        "security": [
+          {
+            "VatsimToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "fileKey",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Deletion result"
+          }
+        }
+      }
+    },
+    "/cdn/upload": {
+      "post": {
+        "summary": "Upload a file to CDN (staff only)",
+        "security": [
+          {
+            "VatsimToken": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "file"
+                ],
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary"
+                  },
+                  "path": {
+                    "type": "string"
+                  },
+                  "key": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "File uploaded"
+          }
+        }
+      }
+    },
+    "/cdn/files": {
+      "get": {
+        "summary": "List CDN files (staff only)",
+        "security": [
+          {
+            "VatsimToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "prefix",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Files listed"
+          }
+        }
+      }
+    },
+    "/euroscope/files/{icao}": {
+      "get": {
+        "summary": "List public EuroScope files for an airport",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "icao",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Files listed"
+          },
+          "400": {
+            "description": "Invalid ICAO"
+          }
+        }
+      }
+    },
+    "/euroscope/upload": {
+      "post": {
+        "summary": "Upload EuroScope file for an airport",
+        "security": [
+          {
+            "VatsimToken": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "file",
+                  "icao"
+                ],
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary"
+                  },
+                  "icao": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "File uploaded"
+          }
+        }
+      }
+    },
+    "/euroscope/files/{icao}/{filename}": {
+      "delete": {
+        "summary": "Delete EuroScope file",
+        "security": [
+          {
+            "VatsimToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "icao",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "filename",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Deletion result"
+          }
+        }
+      }
+    },
+    "/euroscope/{icao}/editable": {
+      "get": {
+        "summary": "Check if EuroScope files are editable by user",
+        "security": [
+          {
+            "VatsimToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "icao",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Permission status returned"
+          }
+        }
+      }
+    },
+    "/purge-cache": {
+      "post": {
+        "summary": "Purge a cache key (lead developer only)",
+        "security": [
+          {
+            "VatsimToken": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "key"
+                ],
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Cache purged"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        }
+      }
+    },
+    "/contributors": {
+      "get": {
+        "summary": "List GitHub contributors",
+        "responses": {
+          "200": {
+            "description": "Contributors returned"
+          }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "summary": "System/service health check",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "service",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "All services healthy"
+          },
+          "503": {
+            "description": "One or more services degraded"
+          }
+        }
+      }
+    }
+  },
+  "components": {},
+  "tags": []
+}

--- a/openapi.json
+++ b/openapi.json
@@ -2,9 +2,19 @@
   "openapi": "3.0.0",
   "info": {
     "title": "BARS Core API",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "description": "API documentation for BARS Core"
   },
+  "servers": [
+    {
+      "url": "https://v2.stopbars.com",
+      "description": "Production"
+    },
+    {
+      "url": "http://localhost:8787",
+      "description": "Local development (wrangler dev)"
+    }
+  ],
   "paths": {
     "/connect": {
       "get": {
@@ -1542,8 +1552,262 @@
           }
         }
       }
+    },
+    "/openapi.json": {
+      "get": {
+        "summary": "Get OpenAPI specification",
+        "description": "Returns the current OpenAPI 3.0 document for the BARS Core API.",
+        "responses": {
+          "200": {
+            "description": "OpenAPI document",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
-  "components": {},
+  "components": {
+    "securitySchemes": {
+      "VatsimToken": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-Vatsim-Token",
+        "description": "VATSIM authentication token obtained via OAuth callback."
+      },
+      "ApiKeyAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "API Key",
+        "description": "User API key passed as Bearer token in Authorization header."
+      }
+    },
+    "schemas": {
+      "Coordinates": {
+        "type": "object",
+        "required": [
+          "lat",
+          "lng"
+        ],
+        "properties": {
+          "lat": {
+            "type": "number",
+            "description": "Latitude in decimal degrees."
+          },
+          "lng": {
+            "type": "number",
+            "description": "Longitude in decimal degrees."
+          }
+        }
+      },
+      "PointData": {
+        "type": "object",
+        "required": [
+          "type",
+          "name",
+          "coordinates"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "stopbar",
+              "lead_on",
+              "taxiway",
+              "stand"
+            ],
+            "description": "Point category."
+          },
+          "name": {
+            "type": "string",
+            "description": "Human readable point name / identifier."
+          },
+          "coordinates": {
+            "$ref": "#/components/schemas/Coordinates"
+          },
+          "directionality": {
+            "type": "string",
+            "enum": [
+              "bi-directional",
+              "uni-directional"
+            ]
+          },
+          "orientation": {
+            "type": "string",
+            "enum": [
+              "left",
+              "right"
+            ]
+          },
+          "color": {
+            "type": "string",
+            "enum": [
+              "yellow",
+              "green",
+              "green-yellow",
+              "green-orange",
+              "green-blue"
+            ]
+          },
+          "elevated": {
+            "type": "boolean"
+          },
+          "ihp": {
+            "type": "boolean",
+            "description": "In pavement (false) vs elevated (true) for some systems."
+          }
+        },
+        "description": "Point creation object. Server assigns id, airportId, created/updated timestamps & createdBy."
+      },
+      "Point": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/PointData"
+          },
+          {
+            "type": "object",
+            "required": [
+              "id",
+              "airportId",
+              "createdAt",
+              "updatedAt",
+              "createdBy"
+            ],
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "airportId": {
+                "type": "string"
+              },
+              "createdAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "updatedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "createdBy": {
+                "type": "string",
+                "description": "VATSIM ID of creator"
+              }
+            },
+            "description": "Persisted point including server-managed fields."
+          }
+        ]
+      },
+      "PointDataPartial": {
+        "type": "object",
+        "description": "Partial PointData used for updates. All properties optional.",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "stopbar",
+              "lead_on",
+              "taxiway",
+              "stand"
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "coordinates": {
+            "type": "object",
+            "properties": {
+              "lat": {
+                "type": "number"
+              },
+              "lng": {
+                "type": "number"
+              }
+            }
+          },
+          "directionality": {
+            "type": "string",
+            "enum": [
+              "bi-directional",
+              "uni-directional"
+            ]
+          },
+          "orientation": {
+            "type": "string",
+            "enum": [
+              "left",
+              "right"
+            ]
+          },
+          "color": {
+            "type": "string",
+            "enum": [
+              "yellow",
+              "green",
+              "green-yellow",
+              "green-orange",
+              "green-blue"
+            ]
+          },
+          "elevated": {
+            "type": "boolean"
+          },
+          "ihp": {
+            "type": "boolean"
+          }
+        }
+      },
+      "PointChangeset": {
+        "type": "object",
+        "description": "Transactional batch of point operations. Operations are applied atomically where possible.",
+        "properties": {
+          "create": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PointData"
+            },
+            "description": "List of new points to create."
+          },
+          "modify": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/PointDataPartial"
+            },
+            "description": "Map of point ID -> partial point data to update."
+          },
+          "delete": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of point IDs to delete."
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string",
+            "description": "Optional machine-readable error code"
+          }
+        },
+        "required": [
+          "error"
+        ],
+        "description": "Standard error envelope."
+      }
+    }
+  },
   "tags": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,61 @@
 			"version": "2.0.0",
 			"dependencies": {
 				"geolib": "^3.3.4",
-				"hono": "^4.8.5"
+				"hono": "^4.8.5",
+				"swagger-jsdoc": "^6.2.8"
 			},
 			"devDependencies": {
 				"@cloudflare/vitest-pool-workers": "^0.8.56",
 				"@types/node": "^24.1.0",
+				"@types/swagger-jsdoc": "^6.0.4",
 				"prettier": "^3.6.2",
 				"typescript": "^5.5.2",
 				"vitest": "^3.1.4",
 				"wrangler": "^4.25.1"
+			}
+		},
+		"node_modules/@apidevtools/json-schema-ref-parser": {
+			"version": "9.1.2",
+			"resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
+			"integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
+			"license": "MIT",
+			"dependencies": {
+				"@jsdevtools/ono": "^7.1.3",
+				"@types/json-schema": "^7.0.6",
+				"call-me-maybe": "^1.0.1",
+				"js-yaml": "^4.1.0"
+			}
+		},
+		"node_modules/@apidevtools/openapi-schemas": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+			"integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@apidevtools/swagger-methods": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+			"integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
+			"license": "MIT"
+		},
+		"node_modules/@apidevtools/swagger-parser": {
+			"version": "10.0.3",
+			"resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
+			"integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
+			"license": "MIT",
+			"dependencies": {
+				"@apidevtools/json-schema-ref-parser": "^9.0.6",
+				"@apidevtools/openapi-schemas": "^2.0.4",
+				"@apidevtools/swagger-methods": "^3.0.2",
+				"@jsdevtools/ono": "^7.1.3",
+				"call-me-maybe": "^1.0.1",
+				"z-schema": "^5.0.1"
+			},
+			"peerDependencies": {
+				"openapi-types": ">=7"
 			}
 		},
 		"node_modules/@cloudflare/kv-asset-handler": {
@@ -1012,6 +1058,12 @@
 				"@jridgewell/sourcemap-codec": "^1.4.10"
 			}
 		},
+		"node_modules/@jsdevtools/ono": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+			"integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+			"license": "MIT"
+		},
 		"node_modules/@poppinss/colors": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.5.tgz",
@@ -1365,6 +1417,12 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/json-schema": {
+			"version": "7.0.15",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+			"license": "MIT"
+		},
 		"node_modules/@types/node": {
 			"version": "24.1.0",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
@@ -1374,6 +1432,13 @@
 			"dependencies": {
 				"undici-types": "~7.8.0"
 			}
+		},
+		"node_modules/@types/swagger-jsdoc": {
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/@types/swagger-jsdoc/-/swagger-jsdoc-6.0.4.tgz",
+			"integrity": "sha512-W+Xw5epcOZrF/AooUM/PccNMSAFOKWZA5dasNyMujTwsBkU74njSJBpvCCJhHAJ95XRMzQrrW844Btu0uoetwQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@vitest/expect": {
 			"version": "3.2.4",
@@ -1513,6 +1578,12 @@
 				"node": ">=0.4.0"
 			}
 		},
+		"node_modules/argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"license": "Python-2.0"
+		},
 		"node_modules/assertion-error": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1522,6 +1593,12 @@
 			"engines": {
 				"node": ">=12"
 			}
+		},
+		"node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"license": "MIT"
 		},
 		"node_modules/birpc": {
 			"version": "0.2.14",
@@ -1540,6 +1617,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/brace-expansion": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
 		"node_modules/cac": {
 			"version": "6.7.14",
 			"resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -1549,6 +1636,12 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/call-me-maybe": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+			"integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+			"license": "MIT"
 		},
 		"node_modules/chai": {
 			"version": "5.2.0",
@@ -1629,6 +1722,21 @@
 				"simple-swizzle": "^0.2.2"
 			}
 		},
+		"node_modules/commander": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+			"integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+			"license": "MIT"
+		},
 		"node_modules/cookie": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
@@ -1690,6 +1798,18 @@
 			"integrity": "sha512-UH8EL6H2ifcY8TbD2QsxwCC/pr5xSwPvv85LrLXVihmHVC3T3YqTCIwnR5ak0yO1KYqlxrPVOA/JVZJYPy2ATg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/doctrine": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+			"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"esutils": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
 		},
 		"node_modules/error-stack-parser-es": {
 			"version": "1.0.5",
@@ -1759,6 +1879,15 @@
 				"@types/estree": "^1.0.0"
 			}
 		},
+		"node_modules/esutils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/exit-hook": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-2.2.1.tgz",
@@ -1804,6 +1933,12 @@
 				}
 			}
 		},
+		"node_modules/fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+			"license": "ISC"
+		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1825,6 +1960,27 @@
 			"integrity": "sha512-EicrlLLL3S42gE9/wde+11uiaYAaeSVDwCUIv2uMIoRBfNJCn8EsSI+6nS3r4TCKDO6+RQNM9ayLq2at+oZQWQ==",
 			"license": "MIT"
 		},
+		"node_modules/glob": {
+			"version": "7.1.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+			"deprecated": "Glob versions prior to v9 are no longer supported",
+			"license": "ISC",
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/glob-to-regexp": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
@@ -1841,6 +1997,23 @@
 				"node": ">=16.9.0"
 			}
 		},
+		"node_modules/inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+			"deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+			"license": "ISC",
+			"dependencies": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"license": "ISC"
+		},
 		"node_modules/is-arrayish": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
@@ -1855,6 +2028,18 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/js-yaml": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"license": "MIT",
+			"dependencies": {
+				"argparse": "^2.0.1"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
 		"node_modules/kleur": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -1864,6 +2049,26 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/lodash.get": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+			"integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+			"deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+			"license": "MIT"
+		},
+		"node_modules/lodash.isequal": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+			"integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+			"deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+			"license": "MIT"
+		},
+		"node_modules/lodash.mergewith": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+			"integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+			"license": "MIT"
 		},
 		"node_modules/loupe": {
 			"version": "3.1.4",
@@ -1932,6 +2137,18 @@
 				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
+		"node_modules/minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/ms": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -1964,6 +2181,31 @@
 			"integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"license": "ISC",
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/openapi-types": {
+			"version": "12.1.3",
+			"resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+			"integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
 		"node_modules/path-to-regexp": {
 			"version": "6.3.0",
@@ -2225,6 +2467,47 @@
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
+		"node_modules/swagger-jsdoc": {
+			"version": "6.2.8",
+			"resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.2.8.tgz",
+			"integrity": "sha512-VPvil1+JRpmJ55CgAtn8DIcpBs0bL5L3q5bVQvF4tAW/k/9JYSj7dCpaYCAv5rufe0vcCbBRQXGvzpkWjvLklQ==",
+			"license": "MIT",
+			"dependencies": {
+				"commander": "6.2.0",
+				"doctrine": "3.0.0",
+				"glob": "7.1.6",
+				"lodash.mergewith": "^4.6.2",
+				"swagger-parser": "^10.0.3",
+				"yaml": "2.0.0-1"
+			},
+			"bin": {
+				"swagger-jsdoc": "bin/swagger-jsdoc.js"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/swagger-jsdoc/node_modules/yaml": {
+			"version": "2.0.0-1",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-1.tgz",
+			"integrity": "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ==",
+			"license": "ISC",
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/swagger-parser": {
+			"version": "10.0.3",
+			"resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
+			"integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
+			"license": "MIT",
+			"dependencies": {
+				"@apidevtools/swagger-parser": "10.0.3"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/tinybench": {
 			"version": "2.9.0",
 			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -2344,6 +2627,15 @@
 				"ohash": "^2.0.11",
 				"pathe": "^2.0.3",
 				"ufo": "^1.6.1"
+			}
+		},
+		"node_modules/validator": {
+			"version": "13.15.15",
+			"resolved": "https://registry.npmjs.org/validator/-/validator-13.15.15.tgz",
+			"integrity": "sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.10"
 			}
 		},
 		"node_modules/vite": {
@@ -3056,6 +3348,12 @@
 				"@esbuild/win32-x64": "0.25.4"
 			}
 		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"license": "ISC"
+		},
 		"node_modules/ws": {
 			"version": "8.18.0",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
@@ -3076,6 +3374,21 @@
 				"utf-8-validate": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/yaml": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+			"integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
 			}
 		},
 		"node_modules/youch": {
@@ -3101,6 +3414,36 @@
 			"dependencies": {
 				"@poppinss/exception": "^1.2.2",
 				"error-stack-parser-es": "^1.0.5"
+			}
+		},
+		"node_modules/z-schema": {
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
+			"integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
+			"license": "MIT",
+			"dependencies": {
+				"lodash.get": "^4.4.2",
+				"lodash.isequal": "^4.5.0",
+				"validator": "^13.7.0"
+			},
+			"bin": {
+				"z-schema": "bin/z-schema"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			},
+			"optionalDependencies": {
+				"commander": "^9.4.1"
+			}
+		},
+		"node_modules/z-schema/node_modules/commander": {
+			"version": "9.5.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+			"integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": "^12.20.0 || >=14"
 			}
 		},
 		"node_modules/zod": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
 				"@types/node": "^24.1.0",
 				"@types/swagger-jsdoc": "^6.0.4",
 				"prettier": "^3.6.2",
+				"ts-node": "^10.9.2",
 				"typescript": "^5.5.2",
 				"vitest": "^3.1.4",
 				"wrangler": "^4.25.1"
@@ -1393,6 +1394,34 @@
 			"dev": true,
 			"license": "CC0-1.0"
 		},
+		"node_modules/@tsconfig/node10": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+			"integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@tsconfig/node12": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+			"integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@tsconfig/node14": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+			"integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@tsconfig/node16": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+			"integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/chai": {
 			"version": "5.2.2",
 			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
@@ -1578,6 +1607,13 @@
 				"node": ">=0.4.0"
 			}
 		},
+		"node_modules/arg": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -1747,6 +1783,13 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/create-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/debug": {
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -1798,6 +1841,16 @@
 			"integrity": "sha512-UH8EL6H2ifcY8TbD2QsxwCC/pr5xSwPvv85LrLXVihmHVC3T3YqTCIwnR5ak0yO1KYqlxrPVOA/JVZJYPy2ATg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/diff": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
 		},
 		"node_modules/doctrine": {
 			"version": "3.0.0",
@@ -2086,6 +2139,13 @@
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.0"
 			}
+		},
+		"node_modules/make-error": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/mime": {
 			"version": "3.0.0",
@@ -2569,6 +2629,50 @@
 				"node": ">=14.0.0"
 			}
 		},
+		"node_modules/ts-node": {
+			"version": "10.9.2",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+			"integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@cspotcode/source-map-support": "^0.8.0",
+				"@tsconfig/node10": "^1.0.7",
+				"@tsconfig/node12": "^1.0.7",
+				"@tsconfig/node14": "^1.0.0",
+				"@tsconfig/node16": "^1.0.2",
+				"acorn": "^8.4.1",
+				"acorn-walk": "^8.1.1",
+				"arg": "^4.1.0",
+				"create-require": "^1.1.0",
+				"diff": "^4.0.1",
+				"make-error": "^1.1.1",
+				"v8-compile-cache-lib": "^3.0.1",
+				"yn": "3.1.1"
+			},
+			"bin": {
+				"ts-node": "dist/bin.js",
+				"ts-node-cwd": "dist/bin-cwd.js",
+				"ts-node-esm": "dist/bin-esm.js",
+				"ts-node-script": "dist/bin-script.js",
+				"ts-node-transpile-only": "dist/bin-transpile.js",
+				"ts-script": "dist/bin-script-deprecated.js"
+			},
+			"peerDependencies": {
+				"@swc/core": ">=1.2.50",
+				"@swc/wasm": ">=1.2.50",
+				"@types/node": "*",
+				"typescript": ">=2.7"
+			},
+			"peerDependenciesMeta": {
+				"@swc/core": {
+					"optional": true
+				},
+				"@swc/wasm": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/tslib": {
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -2628,6 +2732,13 @@
 				"pathe": "^2.0.3",
 				"ufo": "^1.6.1"
 			}
+		},
+		"node_modules/v8-compile-cache-lib": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/validator": {
 			"version": "13.15.15",
@@ -3389,6 +3500,16 @@
 			},
 			"engines": {
 				"node": ">= 14.6"
+			}
+		},
+		"node_modules/yn": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/youch": {

--- a/package.json
+++ b/package.json
@@ -9,11 +9,14 @@
 		"update-db-local": "wrangler d1 execute bars-db --local --file schema.sql",
 		"update-db": "wrangler d1 execute bars-db --remote --file schema.sql",
 		"prettify": "prettier --write .",
-		"build": "wrangler build"
+		"build": "wrangler build",
+		"openapi": "ts-node --esm scripts/generate-openapi.ts"
 	},
 	"devDependencies": {
 		"@cloudflare/vitest-pool-workers": "^0.8.56",
 		"@types/node": "^24.1.0",
+		"@types/swagger-jsdoc": "^6.0.4",
+		"ts-node": "^10.9.2",
 		"prettier": "^3.6.2",
 		"typescript": "^5.5.2",
 		"vitest": "^3.1.4",
@@ -21,6 +24,7 @@
 	},
 	"dependencies": {
 		"geolib": "^3.3.4",
-		"hono": "^4.8.5"
+		"hono": "^4.8.5",
+		"swagger-jsdoc": "^6.2.8"
 	}
 }

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -1,0 +1,18 @@
+import swaggerJsdoc from 'swagger-jsdoc';
+import fs from 'fs';
+
+const options = {
+    definition: {
+        openapi: '3.0.0',
+        info: {
+            title: 'BARS Core API',
+            version: '1.0.0',
+            description: 'API documentation for BARS Core',
+        },
+    },
+    apis: ['./src/**/*.ts'],
+};
+
+const openapiSpec = swaggerJsdoc(options);
+fs.writeFileSync('./openapi.json', JSON.stringify(openapiSpec, null, 2));
+console.log('OpenAPI spec generated at openapi.json');

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -1,16 +1,29 @@
 import swaggerJsdoc from 'swagger-jsdoc';
 import fs from 'fs';
 
+// This script generates the OpenAPI spec by scanning JSDoc comments in the src directory.
+// Component schemas & security schemes are declared in src/openapi-components.ts via @openapi block.
+
 const options = {
     definition: {
         openapi: '3.0.0',
         info: {
             title: 'BARS Core API',
             version: '1.0.0',
-            description: 'API documentation for BARS Core',
+            description: 'API documentation for BARS Core'
         },
+        servers: [
+            {
+                url: 'https://v2.stopbars.com',
+                description: 'Production'
+            },
+            {
+                url: 'http://localhost:8787',
+                description: 'Local development (wrangler dev)'
+            }
+        ]
     },
-    apis: ['./src/**/*.ts'],
+    apis: ['./src/**/*.ts']
 };
 
 const openapiSpec = swaggerJsdoc(options);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1845,6 +1845,24 @@ app.post('/purge-cache', async (c) => {
 	}
 });
 
+// Contributors endpoint
+app.get('/contributors',
+	withCache(() => 'github-contributors', 3600, 'github'), // Cache for 1 hour
+	async (c) => {
+		try {
+			const github = ServicePool.getGitHub(c.env);
+			const contributorsData = await github.getAllContributors();
+			return c.json(contributorsData);
+		} catch (error) {
+			console.error('Contributors endpoint error:', error);
+			return c.json({
+				error: 'Failed to fetch contributors data',
+				message: error instanceof Error ? error.message : 'Unknown error'
+			}, 500);
+		}
+	}
+);
+
 // Health endpoint
 app.get('/health',
 	withCache(CacheKeys.fromUrl, 60, 'health'),

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -1,0 +1,209 @@
+/**
+ * GitHub service for fetching contributor and repository information
+ */
+
+interface GitHubContributor {
+    id: number;
+    login: string;
+    avatar_url: string;
+    html_url: string;
+    type: string;
+    contributions: number;
+    repositories: {
+        name: string;
+        contributions: number;
+    }[];
+}
+
+interface GitHubRepository {
+    name: string;
+    full_name: string;
+    html_url: string;
+    description: string | null;
+    stargazers_count: number;
+    language: string | null;
+    private: boolean;
+    created_at: string;
+    updated_at: string;
+}
+
+interface GitHubContributorResponse {
+    id: number;
+    login: string;
+    avatar_url: string;
+    html_url: string;
+    type: string;
+    contributions: number;
+}
+
+interface ContributorsData {
+    contributors: GitHubContributor[];
+    repositories: {
+        name: string;
+        fullName: string;
+        url: string;
+        description: string | null;
+        stars: number;
+        language: string | null;
+        contributorCount: number;
+        createdAt: string;
+        updatedAt: string;
+    }[];
+    statistics: {
+        totalContributors: number;
+        totalRepositories: number;
+        totalContributions: number;
+    };
+}
+
+export class GitHubService {
+    private readonly GITHUB_ORG = 'stopbars';
+
+    constructor() { }
+
+    /**
+     * Get all public repositories for the organization
+     */
+    private async getOrganizationRepositories(): Promise<GitHubRepository[]> {
+        const repos: GitHubRepository[] = [];
+        let page = 1;
+        const perPage = 100;
+
+        while (true) {
+            const res = await fetch(`https://api.github.com/orgs/${this.GITHUB_ORG}/repos?page=${page}&per_page=${perPage}&type=public`, {
+                headers: {
+                    "User-Agent": "BARS-API",
+                    "Accept": "application/vnd.github.v3+json",
+                },
+            });
+
+            if (!res.ok) {
+                throw new Error(`Failed to fetch GitHub org repos: ${res.status}`);
+            }
+
+            const pageRepos: GitHubRepository[] = await res.json();
+
+            if (pageRepos.length === 0) {
+                break;
+            }
+
+            repos.push(...pageRepos);
+
+            if (pageRepos.length < perPage) {
+                break;
+            }
+
+            page++;
+        }
+
+        return repos;
+    }
+
+    /**
+     * Get contributors for a specific repository
+     */
+    private async getRepositoryContributors(repoFullName: string): Promise<GitHubContributorResponse[]> {
+        try {
+            const res = await fetch(`https://api.github.com/repos/${repoFullName}/contributors?per_page=100`, {
+                headers: {
+                    "User-Agent": "BARS-API",
+                    "Accept": "application/vnd.github.v3+json",
+                },
+            });
+
+            if (!res.ok) {
+                if (res.status === 404) {
+                    // Repository might not exist or be accessible, skip it
+                    return [];
+                }
+                throw new Error(`Failed to fetch GitHub contributors: ${res.status}`);
+            }
+
+            const contributors: GitHubContributorResponse[] = await res.json();
+            return contributors || [];
+        } catch (error) {
+            console.error(`Error fetching contributors for ${repoFullName}:`, error);
+            return [];
+        }
+    }
+
+    /**
+     * Get all contributors across all organization repositories
+     */
+    async getAllContributors(): Promise<ContributorsData> {
+        const allContributors = new Map<number, GitHubContributor>();
+        const repoData: ContributorsData['repositories'] = [];
+
+        // Get all organization repositories
+        const orgRepos = await this.getOrganizationRepositories();
+
+        // Fetch contributors from each repository
+        for (const repoInfo of orgRepos) {
+            try {
+                // Skip private repositories (should already be filtered but double-check)
+                if (repoInfo.private) {
+                    continue;
+                }
+
+                const repoContributors = await this.getRepositoryContributors(repoInfo.full_name);
+
+                repoData.push({
+                    name: repoInfo.name,
+                    fullName: repoInfo.full_name,
+                    url: repoInfo.html_url,
+                    description: repoInfo.description,
+                    stars: repoInfo.stargazers_count,
+                    language: repoInfo.language,
+                    contributorCount: repoContributors.length,
+                    createdAt: repoInfo.created_at,
+                    updatedAt: repoInfo.updated_at,
+                });
+
+                // Merge contributors (avoid duplicates)
+                repoContributors.forEach(contributor => {
+                    if (contributor.type === 'User') { // Exclude bots
+                        if (allContributors.has(contributor.id)) {
+                            // Add contributions from this repo
+                            const existing = allContributors.get(contributor.id)!;
+                            existing.contributions += contributor.contributions;
+                            existing.repositories.push({
+                                name: repoInfo.name,
+                                contributions: contributor.contributions,
+                            });
+                        } else {
+                            // New contributor
+                            allContributors.set(contributor.id, {
+                                ...contributor,
+                                repositories: [{
+                                    name: repoInfo.name,
+                                    contributions: contributor.contributions,
+                                }],
+                            });
+                        }
+                    }
+                });
+            } catch (err) {
+                console.error(`Error fetching ${repoInfo.full_name}:`, err);
+            }
+        }
+
+        // Convert Map to Array and sort by contributions
+        const contributorList = Array.from(allContributors.values())
+            .sort((a, b) => b.contributions - a.contributions);
+
+        // Sort repositories by stars
+        repoData.sort((a, b) => b.stars - a.stars);
+
+        const totalContributions = contributorList.reduce((sum, contributor) => sum + contributor.contributions, 0);
+
+        return {
+            contributors: contributorList,
+            repositories: repoData,
+            statistics: {
+                totalContributors: contributorList.length,
+                totalRepositories: repoData.length,
+                totalContributions,
+            },
+        };
+    }
+}

--- a/src/services/service-pool.ts
+++ b/src/services/service-pool.ts
@@ -13,6 +13,7 @@ import { SupportService } from './support';
 import { NotamService } from './notam';
 import { ContributionService } from './contributions';
 import { StorageService } from './storage';
+import { GitHubService } from './github';
 
 export const ServicePool = (() => {
     let vatsim: VatsimService;
@@ -29,6 +30,7 @@ export const ServicePool = (() => {
     let notam: NotamService;
     let contributions: ContributionService;
     let storage: StorageService;
+    let github: GitHubService;
 
     return {
         getVatsim(env: Env) {
@@ -114,6 +116,12 @@ export const ServicePool = (() => {
                 storage = new StorageService(env.BARS_STORAGE);
             }
             return storage;
+        },
+        getGitHub(env: Env) {
+            if (!github) {
+                github = new GitHubService();
+            }
+            return github;
         }
     };
 })();

--- a/src/types.ts
+++ b/src/types.ts
@@ -153,3 +153,112 @@ export type PointChangeset = {
 	modify?: Record<string, Partial<PointData>>; // Keyed by ID
 	delete?: string[]; // IDs
 };
+
+/**
+ * @openapi
+ * components:
+ *   securitySchemes:
+ *     VatsimToken:
+ *       type: apiKey
+ *       in: header
+ *       name: X-Vatsim-Token
+ *       description: VATSIM authentication token obtained via OAuth callback.
+ *     ApiKeyAuth:
+ *       type: http
+ *       scheme: bearer
+ *       bearerFormat: API Key
+ *       description: User API key passed as Bearer token in Authorization header.
+ *   schemas:
+ *     Coordinates:
+ *       type: object
+ *       required: [lat, lng]
+ *       properties:
+ *         lat:
+ *           type: number
+ *           description: Latitude in decimal degrees.
+ *         lng:
+ *           type: number
+ *           description: Longitude in decimal degrees.
+ *     PointData:
+ *       type: object
+ *       required: [type, name, coordinates]
+ *       properties:
+ *         type:
+ *           type: string
+ *           enum: [stopbar, lead_on, taxiway, stand]
+ *           description: Point category.
+ *         name:
+ *           type: string
+ *           description: Human readable point name / identifier.
+ *         coordinates:
+ *           $ref: '#/components/schemas/Coordinates'
+ *         directionality:
+ *           type: string
+ *           enum: [bi-directional, uni-directional]
+ *         orientation:
+ *           type: string
+ *           enum: [left, right]
+ *         color:
+ *           type: string
+ *           enum: [yellow, green, green-yellow, green-orange, green-blue]
+ *         elevated:
+ *           type: boolean
+ *         ihp:
+ *           type: boolean
+ *           description: In pavement (false) vs elevated (true) for some systems.
+ *       description: Point creation object. Server assigns id, airportId, created/updated timestamps & createdBy.
+ *     Point:
+ *       allOf:
+ *         - $ref: '#/components/schemas/PointData'
+ *         - type: object
+ *           required: [id, airportId, createdAt, updatedAt, createdBy]
+ *           properties:
+ *             id: { type: string }
+ *             airportId: { type: string }
+ *             createdAt: { type: string, format: date-time }
+ *             updatedAt: { type: string, format: date-time }
+ *             createdBy: { type: string, description: 'VATSIM ID of creator' }
+ *           description: Persisted point including server-managed fields.
+ *     PointDataPartial:
+ *       type: object
+ *       description: Partial PointData used for updates. All properties optional.
+ *       properties:
+ *         type: { type: string, enum: [stopbar, lead_on, taxiway, stand] }
+ *         name: { type: string }
+ *         coordinates:
+ *           type: object
+ *           properties:
+ *             lat: { type: number }
+ *             lng: { type: number }
+ *         directionality: { type: string, enum: [bi-directional, uni-directional] }
+ *         orientation: { type: string, enum: [left, right] }
+ *         color: { type: string, enum: [yellow, green, green-yellow, green-orange, green-blue] }
+ *         elevated: { type: boolean }
+ *         ihp: { type: boolean }
+ *     PointChangeset:
+ *       type: object
+ *       description: Transactional batch of point operations. Operations are applied atomically where possible.
+ *       properties:
+ *         create:
+ *           type: array
+ *           items:
+ *             $ref: '#/components/schemas/PointData'
+ *           description: List of new points to create.
+ *         modify:
+ *           type: object
+ *           additionalProperties:
+ *             $ref: '#/components/schemas/PointDataPartial'
+ *           description: Map of point ID -> partial point data to update.
+ *         delete:
+ *           type: array
+ *           items: { type: string }
+ *           description: List of point IDs to delete.
+ *     ErrorResponse:
+ *       type: object
+ *       properties:
+ *         error: { type: string }
+ *         message: { type: string }
+ *         code: { type: string, description: 'Optional machine-readable error code' }
+ *       required: [error]
+ *       description: Standard error envelope.
+ */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,5 +33,5 @@
 		"skipLibCheck": true
 	},
 	"exclude": ["test"],
-	"include": ["worker-configuration.d.ts", "src/**/*.ts"]
+	"include": ["worker-configuration.d.ts", "src/**/*.ts", "scripts/**/*.ts"]
 }


### PR DESCRIPTION
This pull request introduces automated OpenAPI spec generation and commit on deployment, and adds a new `GitHubService` for fetching contributor and repository data from GitHub. It also updates the service pool to provide access to this new GitHub service. The deployment workflow is enhanced to only proceed with deployment if the OpenAPI spec hasn't changed, ensuring the spec is always up-to-date and committed.

**Deployment workflow automation:**

- The GitHub Actions deployment workflow (`.github/workflows/deploy.yml`) now generates the OpenAPI spec, prettifies it, and automatically commits and pushes changes to `openapi.json` if the spec has changed. Deployment and code prettification steps only run if there are no new spec changes to commit. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L8-R8) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R17-R18) [[3]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R28-R53)

**OpenAPI spec generation:**

- Adds a new script `scripts/generate-openapi.ts` to generate the OpenAPI spec using `swagger-jsdoc`, and updates `package.json` with the necessary scripts and dependencies (`swagger-jsdoc`, `ts-node`, `@types/swagger-jsdoc`). [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L12-R28) [[2]](diffhunk://#diff-2665b8f79214c0e2f4f4d1216c621da553a7c4153f8bf7de1f12c54123e5bec7R1-R18)

**GitHub integration:**

- Introduces a new `GitHubService` in `src/services/github.ts` that fetches organization repositories and contributors, aggregates statistics, and exposes a method to retrieve all contributor and repository data.
- Updates the service pool (`src/services/service-pool.ts`) to include and provide the new `GitHubService` via a `getGitHub` method. [[1]](diffhunk://#diff-654d7bb7c730dfe36f84003a7e288157fa33f36850a5d2ea4116d298f425e2dcR16) [[2]](diffhunk://#diff-654d7bb7c730dfe36f84003a7e288157fa33f36850a5d2ea4116d298f425e2dcR33) [[3]](diffhunk://#diff-654d7bb7c730dfe36f84003a7e288157fa33f36850a5d2ea4116d298f425e2dcR119-R124)